### PR TITLE
Bumped version to 2.2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ import Dependencies._
 
 name := "dr-elephant"
 
-version := "2.2.7"
+version := "2.2.10"
 
 organization := "com.linkedin.drelephant"
 


### PR DESCRIPTION
@mittalnanu  As the older versions are already pushed to artifacts but were not reflected in fdp-hadoop-addons, which maintains dr-elephant versions.